### PR TITLE
removed all callbacks from decorators

### DIFF
--- a/src/decorators/errors.ts
+++ b/src/decorators/errors.ts
@@ -1,4 +1,3 @@
-import { Callback } from 'aws-lambda';
 import { Errors, LikeAPIGatewayProxyHandler } from '../types';
 import { nullLogger } from '../utils';
 
@@ -6,32 +5,14 @@ export const errors: Errors = (target, options = {}) => {
   const { body = 'Internal Server Error', logger = nullLogger } = options;
 
   const wrappedHandler: LikeAPIGatewayProxyHandler = async (...args) => {
-    const { 0: event, 1: context, 2: callback } = args;
+    const { 0: event, 1: context } = args;
 
     const response = { body, statusCode: 500 };
-
-    const callbackproxy: Callback = (errors, result) => {
-      if (errors) {
-        logger.error(errors);
-        callback(null, response);
-      } else {
-        callback(null, result);
-      }
-    };
-
-    if (typeof callback === 'function') {
-      try {
-        await target(event, context, callbackproxy);
-      } catch (errors) {
-        callbackproxy(errors);
-      }
-    } else {
-      try {
-        return await target(event, context);
-      } catch (errors) {
-        logger.error(errors);
-        return response;
-      }
+    try {
+      return await target(event, context);
+    } catch (errors) {
+      logger.error(errors);
+      return response;
     }
   };
 

--- a/src/decorators/format-json.ts
+++ b/src/decorators/format-json.ts
@@ -10,7 +10,7 @@ export const formatJSON: FormatJSON = (target, options = {}) => {
     spacing = 0,
   } = options;
   const wrappedHandler: LikeAPIGatewayProxyHandler = async (...args) => {
-    const { 0: event, 1: context, 2: callback } = args;
+    const { 0: event, 1: context } = args;
 
     const response = await target(event, context);
 
@@ -22,11 +22,6 @@ export const formatJSON: FormatJSON = (target, options = {}) => {
         logger.warn(err);
       }
     }
-
-    if (typeof callback === 'function') {
-      return callback(null, response);
-    }
-
     return response;
   };
 

--- a/src/decorators/http-errors.ts
+++ b/src/decorators/http-errors.ts
@@ -18,15 +18,10 @@ export const httpErrors: HttpErrors = (target, options) => {
   const { logger = nullLogger } = options;
 
   const wrappedHandler: LikeAPIGatewayProxyHandler = async (...args) => {
-    const { 0: event, 1: context, 2: callback } = args;
+    const { 0: event, 1: context } = args;
 
     try {
       const response = await target(event, context);
-
-      if (typeof callback === 'function') {
-        return callback(null, response);
-      }
-
       return response;
     } catch (err) {
       const { message = '' } = err;
@@ -47,11 +42,6 @@ export const httpErrors: HttpErrors = (target, options) => {
         const response = { body, statusCode };
 
         logger.info(`httpError: [${statusCode}] "${statusMessage}" "${customMessage || ''}"`);
-
-        if (typeof callback === 'function') {
-          return callback(null, response);
-        }
-
         return response;
       }
 

--- a/src/decorators/warming.ts
+++ b/src/decorators/warming.ts
@@ -9,26 +9,15 @@ export const warming: Warming = (targetHandler, options = {}) => {
   const { eventPayloadCheck = defaultPayloadCheck, logger = nullLogger } = options;
 
   const wrappedHandler: LikeAPIGatewayProxyHandler = async (...args) => {
-    const { 0: event = {}, 1: context, 2: callback } = args;
+    const { 0: event = {}, 1: context } = args;
 
     if (eventPayloadCheck(event)) {
       const response = { body: 'Accepted', statusCode: 202 };
-
       logger.info('Warming event found. Exiting early.');
-
-      if (typeof callback === 'function') {
-        return callback(null, response);
-      }
-
       return response;
     }
 
     const response = await targetHandler(event, context);
-
-    if (typeof callback === 'function') {
-      return callback(null, response);
-    }
-
     return response;
   };
 


### PR DESCRIPTION
Removing all callbacks from decorators
- Lambda looking for callbacks in the arguments, as they are none - giving time out errors.
- If you don't use callback in your code, AWS Lambda will call it implicitly and the return value is null.